### PR TITLE
Drop max_length from deconstruct() and remove CharField 

### DIFF
--- a/cryptographic_fields/fields.py
+++ b/cryptographic_fields/fields.py
@@ -4,7 +4,7 @@ from django.utils.six import with_metaclass
 from django.utils.functional import cached_property
 from django.core import validators
 
-from .settings import FIELD_ENCRYPTION_KEY
+from cryptographic_fields.settings import FIELD_ENCRYPTION_KEY
 
 import cryptography.fernet
 
@@ -45,10 +45,9 @@ class EncryptedMixin(object):
     def __init__(self, *args, **kwargs):
         super(EncryptedMixin, self).__init__(*args, **kwargs)
         # set the max_length to be large enough to contain the encrypted value
-        if not self.max_length:
-            self.max_length = 10
-        self.unencrypted_max_length = self.max_length
-        self.max_length = calc_encrypted_length(self.unencrypted_max_length)
+        if self.max_length:
+            self.unencrypted_max_length = self.max_length
+            self.max_length = calc_encrypted_length(self.unencrypted_max_length)
 
     def to_python(self, value):
         if value is None:
@@ -72,12 +71,21 @@ class EncryptedMixin(object):
             return encrypt_str(unicode(value))
 
     def get_internal_type(self):
-        return "CharField"
+        return "TextField"
+
+    def deconstruct(self):
+        name, path, args, kwargs = super(EncryptedMixin, self).deconstruct()
+
+        if 'max_length' in kwargs:
+            del kwargs['max_length']
+
+        return name, path, args, kwargs
 
 
 class EncryptedCharField(
         with_metaclass(django.db.models.SubfieldBase, EncryptedMixin,
                        django.db.models.CharField)):
+
     pass
 
 
@@ -85,9 +93,6 @@ class EncryptedTextField(
         with_metaclass(django.db.models.SubfieldBase, EncryptedMixin,
                        django.db.models.TextField)):
     pass
-
-    def get_internal_type(self):
-        return "TextField"
 
 
 class EncryptedDateField(

--- a/testapp/tests.py
+++ b/testapp/tests.py
@@ -1,5 +1,6 @@
 import datetime
 
+from django.forms import ModelForm
 from django.test import TestCase
 from django.utils import timezone
 
@@ -131,40 +132,40 @@ class TestModelTestCase(TestCase):
     def test_get_internal_type(self):
         self.assertEqual(
             models.TestModel.enc_char_field.field.get_internal_type(),
-            'CharField')
+            'TextField')
         self.assertEqual(
             models.TestModel.enc_text_field.field.get_internal_type(),
             'TextField')
         self.assertEqual(
             models.TestModel.enc_date_field.field.get_internal_type(),
-            'CharField')
+            'TextField')
         self.assertEqual(
             models.TestModel.enc_date_now_field.field.get_internal_type(),
-            'CharField')
+            'TextField')
         self.assertEqual(
             models.TestModel.enc_boolean_field.field.get_internal_type(),
-            'CharField')
+            'TextField')
         self.assertEqual(
             models.TestModel.enc_null_boolean_field.field.get_internal_type(),
-            'CharField')
+            'TextField')
 
         self.assertEqual(
             models.TestModel.enc_integer_field.field.get_internal_type(),
-            'CharField')
+            'TextField')
         self.assertEqual(
             models.TestModel.enc_positive_integer_field.field.
                 get_internal_type(),
-            'CharField')
+            'TextField')
         self.assertEqual(
             models.TestModel.enc_small_integer_field.field.get_internal_type(),
-            'CharField')
+            'TextField')
         self.assertEqual(
             models.TestModel.enc_positive_small_integer_field.field.
                 get_internal_type(),
-            'CharField')
+            'TextField')
         self.assertEqual(
             models.TestModel.enc_big_integer_field.field.get_internal_type(),
-            'CharField')
+            'TextField')
 
     def test_auto_date(self):
         self.assertTrue(models.TestModel.enc_date_now_field.field.auto_now)
@@ -172,3 +173,15 @@ class TestModelTestCase(TestCase):
         self.assertFalse(models.TestModel.enc_date_now_field.field.auto_now_add)
         self.assertTrue(
             models.TestModel.enc_date_now_add_field.field.auto_now_add)
+
+    def test_max_length_validation(self):
+        class TestModelForm(ModelForm):
+            class Meta:
+                model = models.TestModel
+                fields = ('enc_char_field', )
+
+        f = TestModelForm(data={'enc_char_field': 'a' * 200})
+        self.assertFalse(f.is_valid())
+
+        f = TestModelForm(data={'enc_char_field': 'a' * 99})
+        self.assertTrue(f.is_valid())


### PR DESCRIPTION
* makemigrations checks new_field.deconstruct() and old_field.deconstruct()  to determine if a change needs to be made. These are showing up different no matter how many makemigrations are done. 
* `master` of django-cryptographic-fields makes assumptions about the max_length and updates based on the encryption. However, the underlying encryptor can take arbitrary length so a max_length is really just for front end validation. 
* dropping 'max_length' from the deconstruct() kwargs fixes this issue. However, I do not know how this impacts the charfield.
* No field should really be a char field, in postgres a textfield has the same performance so the only real difference is performance when searching but these can't be searched. 
