### PR TITLE
Make relative import explicit

### DIFF
--- a/cryptographic_fields/fields.py
+++ b/cryptographic_fields/fields.py
@@ -4,7 +4,7 @@ from django.utils.six import with_metaclass
 from django.utils.functional import cached_property
 from django.core import validators
 
-from settings import FIELD_ENCRYPTION_KEY
+from .settings import FIELD_ENCRYPTION_KEY
 
 import cryptography.fernet
 


### PR DESCRIPTION
This commit makes the relative import of the 'settings' module explicit. This is necessary for Python 3 (and a good practice in Python 2)