### PR TITLE
Specifying encrypted_max_length instead of max_length in models

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -45,16 +45,30 @@ To use an encrypted field in a Django model, use one of the fields from the
     from cryptographic_fields.fields import EncryptedCharField
 
     class EncryptedFieldModel(models.Model):
-        encrypted_char_field = EncryptedCharField(max_length=100)
+        encrypted_char_field = EncryptedCharField(encrypted_max_length=100)
 
-For fields that require ``max_length`` to be specified, the ``Encrypted``
-variants of those fields will automatically increase the size of the database
-field to hold the encrypted form of the content. For example, a 3 character
-CharField will automatically specify a database field size of 100 characters
-when ``EncryptedCharField(max_length=3)`` is specified.
+Determining Encrypted Field Length
+----------------------------------
 
-Due to the nature of the encrypted data, filtering by values contained in
-encrypted fields won't work properly. Sorting is also not supported.
+For fields that require ``max_length`` to be specified, you will want to specify
+``encrypted_max_length`` instead of ``max_length``. There is a management
+command to calculate the correct size of ``encrypted_max_length``. So, for a
+field that would normally have a ``max_length`` of 50, you would run the
+following command to get the correct value for ``encrypted_max_length``.
+
+    ./manage.py calculate_max_length 50
+
+You would then use the resulting value to specify ``encrypted_max_length`` in
+your models, instead of passing the traditional ``max_length`` argument.
+
+`Note` that if you decide to skip this step and simply specify ``max_length``,
+the ``Encrypted`` variants of those fields will automatically increase the
+size of the database field to hold the encrypted form of the content. For
+example, a 3 character CharField will automatically specify a database
+field size of 100 characters when ``EncryptedCharField(max_length=3)``
+is specified. The problem with this is that ``django-admin makemigrations`` will
+always create a migration, because it will see that the ``max_length`` of the
+actual model object is different than what you have specified.
 
 Generating an Encryption Key
 ----------------------------
@@ -68,3 +82,8 @@ encryption key to set as ``settings.FIELD_ENCRYPTION_KEY``.
 Running this command will print an encryption key to the terminal, which can
 be configured in your environment or settings file.
 
+Limitations
+-----------
+
+Due to the nature of the encrypted data, filtering by values contained in
+encrypted fields won't work properly. Sorting is also not supported.

--- a/README.rst
+++ b/README.rst
@@ -61,7 +61,7 @@ following command to get the correct value for ``encrypted_max_length``.
 You would then use the resulting value to specify ``encrypted_max_length`` in
 your models, instead of passing the traditional ``max_length`` argument.
 
-`Note` that if you decide to skip this step and simply specify ``max_length``,
+**Note** that if you decide to skip this step and simply specify ``max_length``,
 the ``Encrypted`` variants of those fields will automatically increase the
 size of the database field to hold the encrypted form of the content. For
 example, a 3 character CharField will automatically specify a database

--- a/cryptographic_fields/fields.py
+++ b/cryptographic_fields/fields.py
@@ -43,6 +43,7 @@ def calc_encrypted_length(n):
 
 class EncryptedMixin(object):
     def __init__(self, *args, **kwargs):
+        self.max_length = kwargs.pop('encrypted_max_length', None)
         super(EncryptedMixin, self).__init__(*args, **kwargs)
         # set the max_length to be large enough to contain the encrypted value
         if not self.max_length:

--- a/cryptographic_fields/management/commands/calcuate_max_length.py
+++ b/cryptographic_fields/management/commands/calcuate_max_length.py
@@ -1,0 +1,14 @@
+from django.core.management.base import BaseCommand
+
+from cryptographic_fields.fields import calc_encrypted_length
+
+
+class Command(BaseCommand):
+    help = ('Given a max_length for a field, returns the max length '
+            'required to store encrypted result')
+
+    def add_arguments(self, parser):
+        parser.add_argument('length', nargs=1, type=int)
+
+    def handle(self, *args, **options):
+        self.stdout.write(str(calc_encrypted_length(options['length'][0])))

--- a/testapp/migrations/0002_auto_20160213_2126.py
+++ b/testapp/migrations/0002_auto_20160213_2126.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+import cryptographic_fields.fields
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('testapp', '0001_initial'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='testmodel',
+            name='enc_char_field_no_length_conversion',
+            field=cryptographic_fields.fields.EncryptedCharField(null=True, max_length=396),
+        ),
+    ]

--- a/testapp/models.py
+++ b/testapp/models.py
@@ -5,6 +5,8 @@ from cryptographic_fields import fields
 
 class TestModel(django.db.models.Model):
     enc_char_field = fields.EncryptedCharField(max_length=100)
+    enc_char_field_no_length_conversion = fields.EncryptedCharField(
+        encrypted_max_length=100, null=True)
     enc_text_field = fields.EncryptedTextField()
     enc_date_field = fields.EncryptedDateField(null=True)
     enc_date_now_field = fields.EncryptedDateField(auto_now=True, null=True)

--- a/testapp/tests.py
+++ b/testapp/tests.py
@@ -2,6 +2,7 @@ from __future__ import unicode_literals
 
 import datetime
 
+from cryptographic_fields.fields import calc_encrypted_length
 from django.test import TestCase
 from django.utils import timezone
 
@@ -99,6 +100,7 @@ class TestModelTestCase(TestCase):
 
     def test_raw_value(self):
         inst = models.TestModel()
+        inst.enc_char_field_no_length_conversion = 'This is a test string!'
         inst.enc_char_field = 'This is a test string!'
         inst.enc_text_field = 'This is a test string2!'
         inst.enc_date_field = datetime.date(2011, 1, 1)
@@ -170,3 +172,16 @@ class TestModelTestCase(TestCase):
         self.assertFalse(models.TestModel.enc_date_now_field.field.auto_now_add)
         self.assertTrue(
             models.TestModel.enc_date_now_add_field.field.auto_now_add)
+
+    def test_field_length_conversion(self):
+        """
+        Ensure that length is not converted if encrypted_max_length is provided
+        """
+        BASE_CHAR_LENGTH = 100
+        inst = models.TestModel()
+        converted_char_field = inst._meta.get_field('enc_char_field')
+        non_converted_char_field = inst._meta.get_field(
+            'enc_char_field_no_length_conversion')
+        converted_length = calc_encrypted_length(BASE_CHAR_LENGTH)
+        self.assertEqual(non_converted_char_field.max_length, 100)
+        self.assertEqual(converted_char_field.max_length, converted_length)


### PR DESCRIPTION
This is intended to resolve #11 by asking the user to specify ``encrypted_max_length`` in their models instead of ``max_length``. The user has the option of still using the old method of ``max_length`` with the side effect of migrations being produced every time ``makemigrations`` is run. This seemed reasonable to me since some users might not care (if they have a small app that only requires an initial migration).